### PR TITLE
Group channel names same as prefix

### DIFF
--- a/app/scripts/content.ts
+++ b/app/scripts/content.ts
@@ -151,6 +151,18 @@ class ChannelGrouper {
       prefixes[index] = prefix;
     });
 
+    // Find channels with same name as prefix
+    $channelItems.each(function (index: number, channelItem: HTMLElement) {
+      const $channelName = $(channelItem).find(CHANNEL_NAME_SELECTOR);
+      const channelName = $channelName.data('scg-channel-name');
+
+      if (prefixes.find((prefix: string) =>  channelName === prefix )) {
+        prefixes[index] = channelName;
+        $channelName.data('scg-channel-name', './');
+        $channelName.data('scg-channel-prefix', channelName);
+      }
+    });
+
     // Apply
     $channelItems.each(function (index: number, channelItem: HTMLElement) {
       const $channelName = $(channelItem).find(CHANNEL_NAME_SELECTOR);


### PR DESCRIPTION
If there is a channel with the same name as the prefix, add that channel to the group and rename it `./`.

eg:

before: 
![スクリーンショット 2019-05-27 16 39 55](https://user-images.githubusercontent.com/4771404/58403610-1bbbee80-809e-11e9-8a66-a31bcd1a8490.png)

after: 
![スクリーンショット 2019-05-27 16 17 24](https://user-images.githubusercontent.com/4771404/58402308-f7124780-809a-11e9-9e81-c693c827580c.png)
