### PR TITLE
Fix renaming same channels as prefixes when dynamically changing room structure

### DIFF
--- a/app/scripts/content.ts
+++ b/app/scripts/content.ts
@@ -5,6 +5,7 @@ import * as $ from 'jquery';
 const CHANNEL_LIST_SELECTOR = '.p-channel_sidebar__static_list';
 const CHANNEL_LIST_ITEMS_SELECTOR = CHANNEL_LIST_SELECTOR + ' [role=listitem]';
 const CHANNEL_NAME_SELECTOR = '.p-channel_sidebar__name';
+const CHANNEL_NAME_ROOT = '-/';
 
 // types
 type RequestIdleCallbackHandle = any;
@@ -150,6 +151,10 @@ class ChannelGrouper {
         }
       }
 
+      if (!isApplied) {
+        $channelName.data('scg-raw-channel-name', $channelName.text());
+      }
+
       $channelName.data('scg-channel-name', channelName);
       $channelName.data('scg-channel-prefix', prefix);
       prefixes[index] = prefix;
@@ -158,11 +163,11 @@ class ChannelGrouper {
     // Find channels with same name as prefix
     $channelItems.each(function (index: number, channelItem: HTMLElement) {
       const $channelName = $(channelItem).find(CHANNEL_NAME_SELECTOR);
-      const channelName = $channelName.data('scg-channel-name');
+      const channelName: string = $channelName.data('scg-channel-name');
 
-      if (prefixes.find((prefix: string) =>  channelName === prefix )) {
+      if (prefixes[index + 1] === channelName) {
         prefixes[index] = channelName;
-        $channelName.data('scg-channel-name', './');
+        $channelName.data('scg-channel-name', `${channelName}${CHANNEL_NAME_ROOT}`);
         $channelName.data('scg-channel-prefix', channelName);
       }
     });
@@ -183,7 +188,7 @@ class ChannelGrouper {
       if (isLoneliness) {
         $channelName
           .removeClass('scg-ch-parent scg-ch-child')
-          .text($channelName.data('scg-channel-name'));
+          .text($channelName.data('scg-raw-channel-name'));
       } else {
         if (isParent) {
           separator = '┬';


### PR DESCRIPTION
I'm sorry that #2 caused a bug. Same channel names as prefixes remain `./` when the channel structure is changed dynamically.

bug:
[![Image from Gyazo](https://i.gyazo.com/8f0bba8d1b0b723287db2f6b40c68a85.gif)](https://gyazo.com/8f0bba8d1b0b723287db2f6b40c68a85)

fixed:
[![Image from Gyazo](https://i.gyazo.com/5b8178a9bf0f72d370d1d74a86362587.gif)](https://gyazo.com/5b8178a9bf0f72d370d1d74a86362587)