### PR TITLE
fix: resolve grouping disappearance on tab switching

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,7 +2,7 @@
   "name": "Slack Channels Grouping",
   "short_name": "slack-ch-grp",
   "description": "__MSG_appDescription__",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "manifest_version": 3,
   "default_locale": "en",
   "icons": {

--- a/app/scripts/content/dom-constants.ts
+++ b/app/scripts/content/dom-constants.ts
@@ -7,6 +7,7 @@ export const SELECTOR_WORKSPACE = '.p-client_workspace';
 export const SELECTOR_CHANNEL_LIST_ITEMS = `${SELECTOR_CHANNEL_LIST} [role=listitem], ${SELECTOR_CHANNEL_LIST} [role=treeitem]`;
 export const SELECTOR_CHANNEL_ITEM_CONTENTS_CONTAINER = '.p-channel_sidebar__channel';
 export const SELECTOR_CHANNEL_ITEM_NAME_SELECTOR = '.p-channel_sidebar__name';
+export const SELECTOR_SIDEBAR = '.p-channel_sidebar';
 
 // data attr key
 export const DATA_KEY_CHANNEL_ITEM_CONTENTS_CONTAINER_CHANNEL_TYPE = 'data-qa-channel-sidebar-channel-type';


### PR DESCRIPTION
Fix channel grouping disappearing when switching from DMs tab back to Home tab. Also resolve unwanted line artifacts when switching between workspaces.

Key changes:
- Add comprehensive DOM change monitoring with MutationObserver
- Monitor URL changes and sidebar navigation state
- Enhance workspace switching detection
- Implement proper cleanup of grouping elements
- Add debouncing to prevent excessive updates
- Periodic fallback checks every 3 seconds
- Observer management to prevent memory leaks

Issues resolved:
* Grouping disappearance after tab switching
* Visual artifacts on workspace switching
* Performance optimization
* Resource management improvements